### PR TITLE
sslpsk: add python3.7 support

### DIFF
--- a/sslpsk/sslpsk.py
+++ b/sslpsk/sslpsk.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import ssl
+import _ssl
 import sys
 import weakref
 
@@ -51,10 +52,10 @@ def _sslobj(sock):
 
     """
     pass
-    if sys.version_info >= (3, 5):
-        return sock._sslobj._sslobj
-    else:
+    if isinstance(sock._sslobj, _ssl._SSLSocket):
         return sock._sslobj
+    else:
+        return sock._sslobj._sslobj
 
 def _python_psk_server_callback(ssl_id, identity):
     """Called by _sslpsk.c to return the psk for the socket with the specified


### PR DESCRIPTION
some changes in internal structure of SSLSocket class cause following error:

$ python3.7 -m sslpsk.test
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/developer/.local/lib/python3.7/site-packages/sslpsk/test/test_sslpsk.py", line 67, in accept
    ssl_version=ssl.PROTOCOL_TLSv1, server_side=True)
  File "/home/developer/.local/lib/python3.7/site-packages/sslpsk/sslpsk.py", line 103, in wrap_socket
    _ssl_set_psk_server_callback(sock, cb, hint)
  File "/home/developer/.local/lib/python3.7/site-packages/sslpsk/sslpsk.py", line 77, in _ssl_set_psk_server_callback
    ssl_id = _sslpsk.sslpsk_set_accept_state(_sslobj(sock))
  File "/home/developer/.local/lib/python3.7/site-packages/sslpsk/sslpsk.py", line 55, in _sslobj
    return sock._sslobj._sslobj
AttributeError: '_ssl._SSLSocket' object has no attribute '_sslobj'

Close #4