### PR TITLE
setup: install Windows DLLs in correct location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,50 +14,59 @@
 
 from setuptools import setup, Extension
 
-import sys
+import os, shutil, sys
 
 if sys.platform == 'win32':
     LIB_NAMES = ['ssleay32MD', 'libeay32MD']
-    LIB_FILES = ['openssl/bin/%s.dll'%lib for lib in LIB_NAMES]
 else:
     LIB_NAMES = ['ssl']
-    LIB_FILES = []
 
 _sslpsk = Extension('sslpsk._sslpsk',
                     sources = ['sslpsk/_sslpsk.c'],
                     libraries = LIB_NAMES
 )
-            
-setup(
-    name = 'sslpsk',
-    version = '1.0.0',
-    description = 'Adds TLS-PSK support to the Python ssl package',
-    author = 'David R. Bild',
-    author_email = 'david@davidbild.org',
-    license="Apache 2.0",
-    url = 'https://github.com/drbild/sslpsk',
-    download_url = 'https://github.com/drbild/sslpsk/archive/1.0.0.tar.gz',
-    keywords = ['ssl', 'tls', 'psk', 'tls-psk', 'preshared key'],
-    classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Operating System :: POSIX',
-        'Operating System :: Unix',
-        'Operating System :: MacOS',
-        'Operating System :: Microsoft'
-    ],
-    packages = ['sslpsk', 'sslpsk.test'],
-    ext_modules = [_sslpsk],
-    data_files = [('sslpsk', LIB_FILES)],
-    test_suite = 'sslpsk.test',
-    zip_safe = False
-)
+
+try:
+    # Symlink the libs so they can be included in the package data
+    if sys.platform == 'win32':
+        for lib in LIB_NAMES:
+            shutil.copy2('openssl/bin/%s.dll'%lib, 'sslpsk/')
+
+    setup(
+        name = 'sslpsk',
+        version = '1.0.0',
+        description = 'Adds TLS-PSK support to the Python ssl package',
+        author = 'David R. Bild',
+        author_email = 'david@davidbild.org',
+        license="Apache 2.0",
+        url = 'https://github.com/drbild/sslpsk',
+        download_url = 'https://github.com/drbild/sslpsk/archive/1.0.0.tar.gz',
+        keywords = ['ssl', 'tls', 'psk', 'tls-psk', 'preshared key'],
+        classifiers = [
+            'Development Status :: 5 - Production/Stable',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Operating System :: POSIX',
+            'Operating System :: Unix',
+            'Operating System :: MacOS',
+            'Operating System :: Microsoft'
+        ],
+        packages = ['sslpsk', 'sslpsk.test'],
+        ext_modules = [_sslpsk],
+        package_data = {'' : ['%s.dll'%lib for lib in LIB_NAMES]},
+        test_suite = 'sslpsk.test',
+        zip_safe = False
+    )
+
+finally:
+    if sys.platform == 'win32':
+        for lib in LIB_NAMES:
+            os.remove('sslpsk/%s.dll'%lib)


### PR DESCRIPTION
The packages for Windows include pre-built DLLs for OpenSSL that
should be installed in the sslpsk Python package.  Previously, we used
the `data_files` `setuptools` option to install these. However, it only
worked for the eggs, not wheels. In the wheels, the OpenSSL DLLs were
installed in the wrong location (`python27/sslpsk/` instead of
`python27/Lib/site-packages/sslpsk`).

This commit uses the `package_data` `setuptools` option, instead of
`data_files`, to ensure that the files are installed inside the
package.  To support this, the files must must be copied into the
package source tree during the build.

Fixes #1