### PR TITLE
travis unittests: add more test cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ matrix:
     - os: linux
       python: 3.6
     - os: linux
-      python: 3.7-dev
+      python: 3.7
+    - os: linux
+      python: 3.8
     - os: osx
       language: generic
       env: PYTHON_BIN=python2
@@ -21,4 +23,5 @@ matrix:
 script:
   - $PYTHON_BIN setup.py install
   - cd ..
-  - $PYTHON_BIN -m sslpsk.test
+  - # $PYTHON_BIN -m sslpsk.test
+  - $PYTHON_BIN sslpsk/sslpsk/test/test_sslpsk.py -v -b

--- a/sslpsk/sslpsk.py
+++ b/sslpsk/sslpsk.py
@@ -86,11 +86,8 @@ def wrap_socket(*args, **kwargs):
     do_handshake_on_connect = kwargs.get('do_handshake_on_connect', True)
     kwargs['do_handshake_on_connect'] = False
     
-    psk = kwargs.setdefault('psk', None)
-    del kwargs['psk']
-
-    hint = kwargs.setdefault('hint', None)
-    del kwargs['hint']
+    psk = kwargs.pop('psk', None)
+    hint = kwargs.pop('hint', None)
 
     server_side = kwargs.setdefault('server_side', False)
     if psk:

--- a/sslpsk/test/__init__.py
+++ b/sslpsk/test/__init__.py
@@ -19,4 +19,5 @@ def tests():
     return unittest.TestLoader().discover(os.path.dirname(__file__))
 
 def run():
-    unittest.TextTestRunner(verbosity=1).run(tests())
+    return unittest.TextTestRunner(verbosity=1).run(tests())
+

--- a/sslpsk/test/__main__.py
+++ b/sslpsk/test/__main__.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License
 
+import sys
 import sslpsk.test
 
-sslpsk.test.run()
+result = sslpsk.test.run()
+sys.exit(not result.wasSuccessful())

--- a/sslpsk/test/example_client.py
+++ b/sslpsk/test/example_client.py
@@ -3,8 +3,10 @@ import socket
 import ssl
 import sslpsk
 
-PSKS = {'server1' : b'abcdef',
-        'server2' : b'uvwxyz'}
+PSKS = {
+    b'server1' : b'abcdef',
+    b'server2' : b'uvwxyz',
+}
 
 def client(host, port, psk):
     tcp_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/sslpsk/test/example_server.py
+++ b/sslpsk/test/example_server.py
@@ -3,8 +3,10 @@ import socket
 import ssl
 import sslpsk
 
-PSKS = {'client1' : b'abcdef',
-        'client2' : b'123456'}
+PSKS = {
+        b'client1' : b'abcdef',
+        b'client2' : b'123456',
+    }
 
 def server(host, port):
     tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/sslpsk/test/test_sslpsk.py
+++ b/sslpsk/test/test_sslpsk.py
@@ -204,6 +204,24 @@ class SSLPSKTest(unittest.TestCase):
         self.startServer(myid=b"server1")
         self.connectAndReceiveData()
 
+    def testBareosIdentity(self):
+        def getBareosIdentity(name):
+            identity_prefix = b"R_CONSOLE"
+            record_separator = bytes.fromhex("1E")
+
+            result = identity_prefix + record_separator + name
+
+            return bytes(result)
+
+        clientid = getBareosIdentity(b"client1")
+
+        psks = {b"client1": b"abcdef", b"client2": b"123456", clientid: b"secret"}
+        self.server_psk = lambda identity: psks.get(identity)
+        self.client_psk = (b"secret", clientid)
+
+        self.startServer()
+        self.connectAndReceiveData()
+
 
 
 def main():

--- a/sslpsk/test/test_sslpsk.py
+++ b/sslpsk/test/test_sslpsk.py
@@ -197,6 +197,18 @@ class SslPskTest(SslPskBase):
         self.connectAndReceiveData(ciphers=ciphers)
 
     @unittest.skipUnless(
+        hasattr(ssl, "PROTOCOL_SSLv23"), "ssl module does not provide required protocol"
+    )
+    @unittest.skipIf(
+        os.environ.get("TRAVIS_OS_NAME") == "osx", "Mac OS is known to fail"
+    )
+    def testProtocolSslV23(self):
+        ssl_version = ssl.PROTOCOL_SSLv23
+        self.startServer(ssl_version=ssl_version)
+        self.connectAndReceiveData(ssl_version=ssl_version)
+
+
+    @unittest.skipUnless(
         hasattr(ssl, "PROTOCOL_TLS"), "ssl module does not provide required protocol"
     )
     @unittest.skipIf(

--- a/sslpsk/test/test_sslpsk.py
+++ b/sslpsk/test/test_sslpsk.py
@@ -18,75 +18,163 @@ import ssl
 import sslpsk
 import sys
 import threading
+import traceback
 import unittest
 
-HOST='localhost'
-PORT=6000
-TEST_DATA=b'abcdefghi'
+HOST = "localhost"
+PORT = 6000
+TEST_DATA = b"abcdefghi"
+CIPHERS = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"
+
 
 class SSLPSKTest(unittest.TestCase):
     # ---------- setup/tear down functions
     def setUp(self):
-        self.psk = b'c033f52671c61c8128f7f8a40be88038bcf2b07a6eb3095c36e3759f0cf40837'
+        self.key = b"c033f52671c61c8128f7f8a40be88038bcf2b07a6eb3095c36e3759f0cf40837"
+        self.client_psk = self.key
+        self.server_psk = self.key
         self.addr = (HOST, PORT)
         self.client_socket = socket.socket()
         self.server_socket = None
         self.accept_socket = socket.socket()
         self.client_psk_sock = None
         self.server_psk_sock = None
+        self.server_cipher = None
+        self.server_ssl_version = None
+        self.server_thread = None
+        self.server_thread_exception = None
+        self.server_thread_traceback = None
 
-        self.startServer()
-    
     def tearDown(self):
-        for sock in [self.client_psk_sock or self.client_socket,
-                     self.server_psk_sock or self.server_socket,
-                     self.accept_socket]:
-            try:
-                sock.shutdown(socket.SHUT_RDWR)
-            except socket.error:
-                pass
-            finally:
-                sock.close()
+        if self.server_thread_exception is not None:
+            print("Traceback from server thread ({}):\n".format(self.id()))
+            print(self.server_thread_traceback)
+            print(self.server_thread_exception)
+        for sock in [
+            self.client_psk_sock or self.client_socket,
+            self.server_psk_sock or self.server_socket,
+            self.accept_socket,
+        ]:
+            if sock is not None:
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except socket.error:
+                    pass
+                finally:
+                    sock.close()
 
         self.client_socket = None
         self.server_socket = None
         self.accept_socket = None
         self.client_psk_sock = None
         self.server_psk_sock = None
+        if self.server_thread is not None:
+            self.server_thread.join()
+            self.server_thread = None
 
-    def startServer(self):
+    def startServer(self, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=CIPHERS, myid=None):
         self.accept_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.accept_socket.bind(self.addr)
         self.accept_socket.listen(1)
+        self.server_ciphers = ciphers
+        self.server_ssl_version = ssl_version
+        self.server_id = myid
 
         def accept():
-            self.server_socket, _ = self.accept_socket.accept()
-        
-            # wrap socket with TLS-PSK
-            self.server_psk_sock = sslpsk.wrap_socket(self.server_socket, psk=self.psk, ciphers='PSK-AES256-CBC-SHA',
-                                                      ssl_version=ssl.PROTOCOL_TLSv1, server_side=True)
-        
+            try:
+                self.server_socket, _ = self.accept_socket.accept()
+            except Exception as exc:
+                self.server_thread_exception = exc
+                self.server_thread_traceback = "".join(
+                    traceback.format_tb(exc.__traceback__)
+                )
+                return
+
+            try:
+                # wrap socket with TLS-PSK
+                self.server_psk_sock = sslpsk.wrap_socket(
+                    self.server_socket,
+                    psk=self.server_psk,
+                    ciphers=self.server_ciphers,
+                    ssl_version=self.server_ssl_version,
+                    server_side=True,
+                    hint=self.server_id,
+                )
+            except Exception as exc:
+                self.server_thread_exception = exc
+                self.server_thread_traceback = "".join(
+                    traceback.format_tb(exc.__traceback__)
+                )
+                return
+
             # accept data from client
             data = self.server_psk_sock.recv(10)
             self.server_psk_sock.sendall(data.upper())
 
-        threading.Thread(target = accept).start()
+        self.server_thread = threading.Thread(target=accept)
+        self.server_thread.start()
 
-    def testClient(self):
+    def connectAndReceiveData(
+        self, ssl_version=ssl.PROTOCOL_TLSv1, ciphers=CIPHERS, myid=None
+    ):
         # initialize
         self.client_socket.connect(self.addr)
-        
+
         # wrap socket with TLS-PSK
-        self.client_psk_sock = sslpsk.wrap_socket(self.client_socket, psk=self.psk, ciphers='PSK-AES256-CBC-SHA',
-                                                  ssl_version=ssl.PROTOCOL_TLSv1, server_side=False)
-        
+        self.client_psk_sock = sslpsk.wrap_socket(
+            self.client_socket,
+            psk=self.client_psk,
+            ciphers=ciphers,
+            ssl_version=ssl_version,
+            server_side=False,
+            hint=myid,
+        )
+
         self.client_psk_sock.sendall(TEST_DATA)
         data = self.client_psk_sock.recv(10)
-        print('data: %s' % data)
-        self.assertTrue(data == TEST_DATA.upper(), 'Test Failed')
+        self.assertTrue(data == TEST_DATA.upper(), "Test Failed")
+
+    def testClientCiphersPskAes256(self):
+        ciphers = "PSK-AES256-CBC-SHA"
+        ssl_version = ssl.PROTOCOL_TLSv1
+        self.startServer(ssl_version, ciphers)
+        self.connectAndReceiveData(ssl_version, ciphers)
+
+    def testCiphersAll(self):
+        ciphers = "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"
+        ssl_version = ssl.PROTOCOL_TLSv1
+        self.startServer(ssl_version, ciphers)
+        self.connectAndReceiveData(ssl_version, ciphers)
+
+    @unittest.expectedFailure
+    def testProtocolTls(self):
+        ssl_version = ssl.PROTOCOL_TLS
+        self.startServer(ssl_version=ssl_version)
+        self.connectAndReceiveData(ssl_version=ssl_version)
+
+    def testProtocolTlsV1(self):
+        ssl_version = ssl.PROTOCOL_TLSv1
+        self.startServer(ssl_version=ssl_version)
+        self.connectAndReceiveData(ssl_version=ssl_version)
+
+    def testProtocolTlsV1_1(self):
+        ssl_version = ssl.PROTOCOL_TLSv1_1
+        self.startServer(ssl_version=ssl_version)
+        self.connectAndReceiveData(ssl_version=ssl_version)
+
+    def testProtocolTlsV1_2(self):
+        ssl_version = ssl.PROTOCOL_TLSv1_2
+        self.startServer(ssl_version=ssl_version)
+        self.connectAndReceiveData(ssl_version=ssl_version)
+
+    def testProtocolClientTlsV1_2ServerTls(self):
+        self.startServer(ssl_version=ssl.PROTOCOL_TLS)
+        self.connectAndReceiveData(ssl_version=ssl.PROTOCOL_TLSv1_2)
+
 
 def main():
-    unittest.main(buffer=False)
+    unittest.main(warnings="ignore")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Add more test cases and makes it possible to separately test client and server parts (by connecting against the openssl binary).