### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ try:
 
     setup(
         name = 'sslpsk',
-        version = '1.0.0',
+        version = '1.1.0',
         description = 'Adds TLS-PSK support to the Python ssl package',
         author = 'David R. Bild',
         author_email = 'david@davidbild.org',


### PR DESCRIPTION
Bump version to 1.1.0 for changes to python support. This helps even if there is no new release as we can mark the version need in requirements files.